### PR TITLE
Closes #9: Updated README.md to reflect 0.1.1 change on props name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ An example of the implementation code for a given `SimpleButton` component:
         constructor(props) {
             super(props)
 
-            const { styles } = this.props;
+            const { styleManager } = this.props;
 
-            styles
+            styleManager
                 .change('root')
                 .when(this.isDisabled)
                 .apply({
@@ -31,7 +31,7 @@ An example of the implementation code for a given `SimpleButton` component:
                     cursor: 'not-allowed',
                 });
 
-            styles
+            styleManager
                 .change('button')
                 .when(this.isDisabled)
                 .apply({


### PR DESCRIPTION
`StyleManager` is now being pushed as `styleManager`, not as `styles`. I've updated the `README.md` example code to reflect this.